### PR TITLE
Fix npm publish workflow for @wizardtower/tablet

### DIFF
--- a/.github/workflows/publish-npm-version.yml
+++ b/.github/workflows/publish-npm-version.yml
@@ -2,19 +2,22 @@ name: Publish Package to npmjs
 on:
   release:
     types: [published]
+  workflow_dispatch:
+
 jobs:
   npm-publish:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Use Node.js 18.x
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 18.x
-          registry-url: 'https://registry.npmjs.org'
+          registry-url: https://registry.npmjs.org
       - run: npm ci
       - run: npm run tsc
-      - name: Authenticate with private NPM package
-        run: echo "//registry.npmjs.org/:_authToken=${{secrets.NPM_PUBLISH_TABLET}}" > .npmrc
-      - run: npm publish
+      - name: Publish to npm
+        run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TABLET }}

--- a/package.json
+++ b/package.json
@@ -31,6 +31,9 @@
     "url": "https://github.com/Arcane-Laboratory/Tablet/issues"
   },
   "homepage": "https://github.com/Arcane-Laboratory/Tablet#readme",
+  "publishConfig": {
+    "access": "public"
+  },
   "devDependencies": {
     "@types/jest": "^27.5.2",
     "@types/node": "^18.11.3",


### PR DESCRIPTION
## Summary
The `v1.1.2` release publish failed with npm `E404` when pushing `@wizardtower/tablet`.

This updates the publish workflow to use the standard `NODE_AUTH_TOKEN` auth path with `actions/setup-node`, adds `publishConfig.access: public` for the scoped package, and enables `workflow_dispatch` so publish can be retried manually after the npm token is refreshed.

## Root cause
- CI log: `404 Not Found - PUT https://registry.npmjs.org/@wizardtower%2ftablet`
- `@wizardtower/tablet` is not currently on the public npm registry
- `NPM_PUBLISH_TABLET` was last updated 2025-10-16; publishes have failed since `v1.0.2`

The workflow also wrote a project-root `.npmrc` while `setup-node` configured a separate temp npmrc, which is fragile for scoped publishes.

## After merge
1. Create a new npm **Automation** token with publish access to the `@wizardtower` scope
2. Update the repo secret `NPM_PUBLISH_TABLET` in GitHub
3. Re-run **Publish Package to npmjs** via Actions → workflow_dispatch (no version bump needed; `1.1.2` was never published)

## Test plan
- [ ] Merge PR
- [ ] Rotate `NPM_PUBLISH_TABLET`
- [ ] Manually dispatch publish workflow and confirm `@wizardtower/tablet@1.1.2` appears on npm


Made with [Cursor](https://cursor.com)