### PR TITLE
Switch npm publish to Trusted Publishing (OIDC)

### DIFF
--- a/.github/workflows/publish-npm-version.yml
+++ b/.github/workflows/publish-npm-version.yml
@@ -25,4 +25,4 @@ jobs:
       - run: npm ci
       - run: npm run tsc
       - name: Publish to npm via Trusted Publishing
-        run: npm publish --access public
+        run: npm publish

--- a/.github/workflows/publish-npm-version.yml
+++ b/.github/workflows/publish-npm-version.yml
@@ -4,20 +4,25 @@ on:
     types: [published]
   workflow_dispatch:
 
+permissions:
+  id-token: write # Required for npm Trusted Publishing (OIDC)
+  contents: read
+
 jobs:
   npm-publish:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Use Node.js 18.x
+      - name: Use Node.js 24.x
         uses: actions/setup-node@v4
         with:
-          node-version: 18.x
+          node-version: 24.x
           registry-url: https://registry.npmjs.org
+          package-manager-cache: false
+      - name: Upgrade npm for OIDC trusted publishing
+        run: npm install -g npm@latest
       - run: npm ci
       - run: npm run tsc
-      - name: Publish to npm
+      - name: Publish to npm via Trusted Publishing
         run: npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TABLET }}

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   },
   "homepage": "https://github.com/Arcane-Laboratory/Tablet#readme",
   "publishConfig": {
-    "access": "public"
+    "access": "restricted"
   },
   "devDependencies": {
     "@types/jest": "^27.5.2",


### PR DESCRIPTION
## Summary
- Remove `NODE_AUTH_TOKEN` / `NPM_PUBLISH_TABLET` from the publish workflow
- Add `permissions.id-token: write` for npm Trusted Publishing
- Use Node 24 + `npm@latest` (npm CLI 11.5.1+ required for OIDC)
- Publish as a **private** scoped package (`publishConfig.access: restricted`, no `--access public`)
- Keep `workflow_dispatch` and release triggers for retries

## npm setup required (one-time)

`@wizardtower/tablet` already exists on npm as a **private** package. Configure Trusted Publishing on it:

Go to: https://www.npmjs.com/package/@wizardtower/tablet/access → **Trusted Publisher**

| Field | Value |
|-------|-------|
| Provider | GitHub Actions |
| Organization or user | `Arcane-Laboratory` |
| Repository | `Tablet` |
| Workflow filename | `publish-npm-version.yml` |
| Allowed actions | `npm publish` |

The workflow filename must match exactly (case-sensitive).

## Publish 1.1.2

After merge + npm Trusted Publisher config:
- Actions → **Publish Package to npmjs** → **Run workflow**

No version bump needed; `1.1.2` was never published successfully.

## Notes on private packages

- Do **not** use `--access public`; that was likely contributing to the earlier publish failures.
- Provenance attestations are not auto-generated for private packages (expected).
- Once OIDC publish is verified, you can revoke `NPM_PUBLISH_TABLET` and optionally enable npm's "disallow tokens" setting.

## Test plan
- [ ] Merge PR
- [ ] Configure Trusted Publisher with values above
- [ ] Run workflow_dispatch and confirm `@wizardtower/tablet@1.1.2` is available on npm (authenticated)