### PR TITLE
Fix npm publish sigstore MODULE_NOT_FOUND

### DIFF
--- a/.github/workflows/publish-npm-version.yml
+++ b/.github/workflows/publish-npm-version.yml
@@ -26,3 +26,5 @@ jobs:
       - run: npm run tsc
       - name: Publish to npm via Trusted Publishing
         run: npm publish
+        env:
+          NPM_CONFIG_PROVENANCE: false

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
   },
   "homepage": "https://github.com/Arcane-Laboratory/Tablet#readme",
   "publishConfig": {
-    "access": "restricted"
+    "access": "restricted",
+    "provenance": false
   },
   "devDependencies": {
     "@types/jest": "^27.5.2",


### PR DESCRIPTION
## Summary
Publish failed with:
```
npm error Cannot find module 'sigstore'
npm error Require stack: .../libnpmpublish/lib/provenance.js
```

Trusted publishing was triggering provenance generation, but the CI npm install does not include the `sigstore` dependency. For this **private** package, provenance attestations are not needed anyway.

## Fix
- Set `publishConfig.provenance: false` in `package.json`
- Set `NPM_CONFIG_PROVENANCE: false` on the publish step

## Test plan
- [ ] Merge PR
- [ ] Re-run **Publish Package to npmjs** workflow_dispatch
- [ ] Confirm `@wizardtower/tablet@1.1.2` publishes successfully


Made with [Cursor](https://cursor.com)