### PR TITLE
Fix npm publish: sigstore + OIDC auth conflict

### DIFF
--- a/.github/workflows/publish-npm-version.yml
+++ b/.github/workflows/publish-npm-version.yml
@@ -18,10 +18,12 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 24.x
-          registry-url: https://registry.npmjs.org
           package-manager-cache: false
-      - name: Upgrade npm for OIDC trusted publishing
-        run: npm install -g npm@latest
+      - name: Prepare npm for OIDC trusted publishing
+        run: |
+          npm --version
+          npm install -g npm@latest sigstore
+          npm --version
       - run: npm ci
       - run: npm run tsc
       - name: Publish to npm via Trusted Publishing


### PR DESCRIPTION
## Problem (Actions run #21)

Publish still failed with:
```
npm error Cannot find module 'sigstore'
.../libnpmpublish/lib/provenance.js
```

Two issues in the current workflow:

1. **`sigstore` missing after global npm upgrade** — `npm install -g npm@latest` strips optional deps; `libnpmpublish` requires `sigstore` at module load time (even with `NPM_CONFIG_PROVENANCE=false`).

2. **`NODE_AUTH_TOKEN` from `setup-node`** — With `registry-url` set, `setup-node` defaults to injecting `GITHUB_TOKEN` as `NODE_AUTH_TOKEN`, which can interfere with npm Trusted Publishing (OIDC).

## Fix

- Remove `registry-url` from `setup-node` (no private npm deps to install; `npm ci` works without auth)
- Install both `npm@latest` and `sigstore` globally before publish
- Keep `NPM_CONFIG_PROVENANCE: false` for this private package

## Test plan

- [ ] Merge PR
- [ ] Re-run **Publish Package to npmjs** (workflow_dispatch, run #22+)
- [ ] Confirm `@wizardtower/tablet@1.1.2` publishes successfully via OIDC


Made with [Cursor](https://cursor.com)