### PR TITLE
Bump to 1.1.3 for npm republish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.3]
+
+- Republish after fixing npm Trusted Publishing CI workflow (OIDC + sigstore).
+
 ## [1.1.2]
 
 - Fixed `SheetTable.crupdate` auto-id generation: `==` comparison replaced with `??=` assignment so entries without `_id` receive a new UUID.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wizardtower/tablet",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "DB abstraction layer for JSON, Sheets, MongoDB, etc.",
   "main": "./built/index.js",
   "exports": {


### PR DESCRIPTION
## Summary
The latest publish run (#22) **succeeded at authentication** and reached npm, but failed with:

```
403 Forbidden - You cannot publish over the previously published versions: 1.1.2.
```

Trusted Publishing (OIDC) is working. `@wizardtower/tablet@1.1.2` is already on the registry, so CI needs a new version to publish.

## Changes
- Bump version `1.1.2` → `1.1.3`
- Update CHANGELOG

## After merge
- Re-run **Publish Package to npmjs** via workflow_dispatch, or
- Create GitHub release `v1.1.3`


Made with [Cursor](https://cursor.com)