### PR TITLE
fix(mongo): use findOneAndUpdate with $set in MongoTable.crupdate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+- Fixed `MongoTable.crupdate` for MongoDB Node driver 6.x: use `findOneAndReplace` instead of `findOneAndUpdate` with a plain document, which caused `MongoInvalidArgumentError: Update document requires atomic operators` on save.
+
 ## [1.1.3]
 
 - Republish after fixing npm Trusted Publishing CI workflow (OIDC + sigstore).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- Fixed `MongoTable.crupdate` for MongoDB Node driver 6.x: use `findOneAndReplace` instead of `findOneAndUpdate` with a plain document, which caused `MongoInvalidArgumentError: Update document requires atomic operators` on save.
+- Fixed `MongoTable.crupdate` for MongoDB Node driver 6.x: wrap updates in `$set` for `findOneAndUpdate`, fixing `MongoInvalidArgumentError: Update document requires atomic operators` on save.
 
 ## [1.1.3]
 

--- a/src/mongodb/MongoTable.crupdate.test.ts
+++ b/src/mongodb/MongoTable.crupdate.test.ts
@@ -1,0 +1,99 @@
+import { MongoClient } from 'mongodb'
+import { MongoTable } from './MongoTable'
+import { Table } from '../Table'
+import { tableData } from '../../types/tableTypes'
+
+interface TestEntry extends tableData {
+  name: string
+}
+
+const mockFindOneAndReplace = jest.fn()
+const mockCollection = {
+  findOneAndReplace: mockFindOneAndReplace,
+}
+const mockDb = {
+  collection: jest.fn().mockReturnValue(mockCollection),
+}
+const mockClient = {
+  connect: jest.fn().mockResolvedValue(undefined),
+  db: jest.fn().mockReturnValue(mockDb),
+} as unknown as MongoClient
+
+function createTable(name: string): MongoTable<TestEntry> {
+  return new MongoTable<TestEntry>(mockClient, 'test-db', name)
+}
+
+describe('MongoTable.crupdate', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    Table.all.clear()
+    mockClient.connect = jest.fn().mockResolvedValue(undefined)
+    mockClient.db = jest.fn().mockReturnValue(mockDb)
+    mockDb.collection.mockReturnValue(mockCollection)
+  })
+
+  it('updates a versioned entry and increments _version', async () => {
+    const table = createTable('VersionedUpdate')
+    await table.loadPromise
+
+    const entry: TestEntry = {
+      _id: 'player-1',
+      name: 'Ada',
+      _version: 3,
+    }
+    const saved: TestEntry = { ...entry, _version: 4, name: 'Ada' }
+    mockFindOneAndReplace.mockResolvedValue(saved)
+
+    const result = await table.crupdate(entry)
+
+    expect(result).toEqual(saved)
+    expect(mockFindOneAndReplace).toHaveBeenCalledWith(
+      { _id: 'player-1', _version: 3 },
+      { _id: 'player-1', name: 'Ada', _version: 4 },
+      { upsert: false, returnDocument: 'after' }
+    )
+  })
+
+  it('upserts an unversioned entry starting at _version 1', async () => {
+    const table = createTable('UnversionedUpsert')
+    await table.loadPromise
+
+    const entry: TestEntry = {
+      _id: 'player-2',
+      name: 'Bea',
+      _version: undefined,
+    }
+    const saved: TestEntry = { ...entry, _version: 1 }
+    mockFindOneAndReplace.mockResolvedValue(saved)
+
+    const result = await table.crupdate(entry)
+
+    expect(result).toEqual(saved)
+    expect(mockFindOneAndReplace).toHaveBeenCalledWith(
+      { _id: 'player-2' },
+      { _id: 'player-2', name: 'Bea', _version: 1 },
+      { upsert: true, returnDocument: 'after' }
+    )
+  })
+
+  it('returns false when a versioned update matches no document', async () => {
+    const table = createTable('StaleVersion')
+    await table.loadPromise
+
+    const entry: TestEntry = {
+      _id: 'player-3',
+      name: 'Cyd',
+      _version: 1,
+    }
+    mockFindOneAndReplace.mockResolvedValue(null)
+
+    const result = await table.crupdate(entry)
+
+    expect(result).toBe(false)
+    expect(mockFindOneAndReplace).toHaveBeenCalledWith(
+      { _id: 'player-3', _version: 1 },
+      { _id: 'player-3', name: 'Cyd', _version: 2 },
+      { upsert: false, returnDocument: 'after' }
+    )
+  })
+})

--- a/src/mongodb/MongoTable.crupdate.test.ts
+++ b/src/mongodb/MongoTable.crupdate.test.ts
@@ -7,9 +7,9 @@ interface TestEntry extends tableData {
   name: string
 }
 
-const mockFindOneAndReplace = jest.fn()
+const mockFindOneAndUpdate = jest.fn()
 const mockCollection = {
-  findOneAndReplace: mockFindOneAndReplace,
+  findOneAndUpdate: mockFindOneAndUpdate,
 }
 const mockDb = {
   collection: jest.fn().mockReturnValue(mockCollection),
@@ -32,7 +32,7 @@ describe('MongoTable.crupdate', () => {
     mockDb.collection.mockReturnValue(mockCollection)
   })
 
-  it('updates a versioned entry and increments _version', async () => {
+  it('updates a versioned entry with $set and increments _version', async () => {
     const table = createTable('VersionedUpdate')
     await table.loadPromise
 
@@ -42,14 +42,14 @@ describe('MongoTable.crupdate', () => {
       _version: 3,
     }
     const saved: TestEntry = { ...entry, _version: 4, name: 'Ada' }
-    mockFindOneAndReplace.mockResolvedValue(saved)
+    mockFindOneAndUpdate.mockResolvedValue(saved)
 
     const result = await table.crupdate(entry)
 
     expect(result).toEqual(saved)
-    expect(mockFindOneAndReplace).toHaveBeenCalledWith(
+    expect(mockFindOneAndUpdate).toHaveBeenCalledWith(
       { _id: 'player-1', _version: 3 },
-      { _id: 'player-1', name: 'Ada', _version: 4 },
+      { $set: { name: 'Ada', _version: 4 } },
       { upsert: false, returnDocument: 'after' }
     )
   })
@@ -64,14 +64,14 @@ describe('MongoTable.crupdate', () => {
       _version: undefined,
     }
     const saved: TestEntry = { ...entry, _version: 1 }
-    mockFindOneAndReplace.mockResolvedValue(saved)
+    mockFindOneAndUpdate.mockResolvedValue(saved)
 
     const result = await table.crupdate(entry)
 
     expect(result).toEqual(saved)
-    expect(mockFindOneAndReplace).toHaveBeenCalledWith(
+    expect(mockFindOneAndUpdate).toHaveBeenCalledWith(
       { _id: 'player-2' },
-      { _id: 'player-2', name: 'Bea', _version: 1 },
+      { $set: { name: 'Bea', _version: 1 } },
       { upsert: true, returnDocument: 'after' }
     )
   })
@@ -85,14 +85,14 @@ describe('MongoTable.crupdate', () => {
       name: 'Cyd',
       _version: 1,
     }
-    mockFindOneAndReplace.mockResolvedValue(null)
+    mockFindOneAndUpdate.mockResolvedValue(null)
 
     const result = await table.crupdate(entry)
 
     expect(result).toBe(false)
-    expect(mockFindOneAndReplace).toHaveBeenCalledWith(
+    expect(mockFindOneAndUpdate).toHaveBeenCalledWith(
       { _id: 'player-3', _version: 1 },
-      { _id: 'player-3', name: 'Cyd', _version: 2 },
+      { $set: { name: 'Cyd', _version: 2 } },
       { upsert: false, returnDocument: 'after' }
     )
   })

--- a/src/mongodb/MongoTable.ts
+++ b/src/mongodb/MongoTable.ts
@@ -40,7 +40,7 @@ class MongoTable<T extends tableData> extends Table<T> {
     return this.toArray()
   }
   /**
-   * if the entry has no version, create it with version 0, upsert
+   * if the entry has no version, create it with version 1, upsert
    * if the entry has a version, only update if the version matches and increment the version
    */
   public async crupdate(entry: T): Promise<T | false> {
@@ -53,12 +53,15 @@ class MongoTable<T extends tableData> extends Table<T> {
         } as Filter<T>)
       : ({ _id: entry._id } as Filter<T>)
     const newVersion = entry._version ? entry._version + 1 : 1
-    const result = await this.collection.findOneAndUpdate(
+    const replacement = {
+      ...entry,
+      _version: newVersion,
+    }
+    // findOneAndUpdate requires atomic operators ($set, etc.); we replace the
+    // full document, so use findOneAndReplace (same semantics as legacy replaceOne).
+    const result = await this.collection.findOneAndReplace(
       filter,
-      {
-        ...entry,
-        _version: newVersion,
-      },
+      replacement,
       {
         upsert: !isVersioned,
         returnDocument: 'after',

--- a/src/mongodb/MongoTable.ts
+++ b/src/mongodb/MongoTable.ts
@@ -1,6 +1,6 @@
 import { tableData } from '../../types/tableTypes'
 import { Table } from '../Table'
-import { Collection, Filter, MongoClient } from 'mongodb'
+import { Collection, Filter, MatchKeysAndValues, MongoClient } from 'mongodb'
 
 class MongoTable<T extends tableData> extends Table<T> {
   public loadPromise: Promise<boolean>
@@ -46,22 +46,22 @@ class MongoTable<T extends tableData> extends Table<T> {
   public async crupdate(entry: T): Promise<T | false> {
     await this.loadPromise
     const isVersioned = entry._version !== undefined
+    const { _id, ...entryDataWithoutId } = entry
     const filter = isVersioned
       ? ({
-          _id: entry._id,
+          _id,
           _version: entry._version,
         } as Filter<T>)
-      : ({ _id: entry._id } as Filter<T>)
+      : ({ _id } as Filter<T>)
     const newVersion = entry._version ? entry._version + 1 : 1
-    const replacement = {
-      ...entry,
-      _version: newVersion,
-    }
-    // findOneAndUpdate requires atomic operators ($set, etc.); we replace the
-    // full document, so use findOneAndReplace (same semantics as legacy replaceOne).
-    const result = await this.collection.findOneAndReplace(
+    const result = await this.collection.findOneAndUpdate(
       filter,
-      replacement,
+      {
+        $set: {
+          ...entryDataWithoutId,
+          _version: newVersion,
+        } as MatchKeysAndValues<T>,
+      },
       {
         upsert: !isVersioned,
         returnDocument: 'after',


### PR DESCRIPTION
## Summary
- Fixes `MongoTable.crupdate` for MongoDB Node driver 6.x by wrapping updates in `$set` for `findOneAndUpdate` (plain documents threw `MongoInvalidArgumentError: Update document requires atomic operators`).
- Omits `_id` from the `$set` payload; preserves optimistic `_version` locking, unversioned upserts, and `returnDocument: 'after'`.
- Adds unit tests asserting the `$set` call shape for versioned update, unversioned upsert, and stale version mismatch.
- Closes #17

## Test plan
- [x] `npm test -- --testPathPattern=MongoTable.crupdate`
- [ ] After merge/publish as `@wizardtower/tablet@1.1.4`, bump Sunfall and verify `Player.save` on staging

Made with [Cursor](https://cursor.com)