### PR TITLE
fix(sheets): SheetTable.fetchAll stale cache blocks string sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.5]
+
+- Fixed `SheetTable.fetchAll` stale cache: each call (default `forceRefresh=true`) reloads from Google Sheets and clears `loadPromise` afterward so CMS/string sync picks up live edits without restart.
+
 ## [1.1.4]
 
 - Fixed `MongoTable.crupdate` for MongoDB Node driver 6.x: wrap updates in `$set` for `findOneAndUpdate`, fixing `MongoInvalidArgumentError: Update document requires atomic operators` on save.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@wizardtower/tablet",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@wizardtower/tablet",
-      "version": "1.1.4",
+      "version": "1.1.5",
       "license": "MIT",
       "dependencies": {
         "eslint": "^8.26.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wizardtower/tablet",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "description": "DB abstraction layer for JSON, Sheets, MongoDB, etc.",
   "main": "./built/index.js",
   "exports": {

--- a/src/sheets/SheetTable.fetchAll.test.ts
+++ b/src/sheets/SheetTable.fetchAll.test.ts
@@ -1,0 +1,132 @@
+import { SheetTable } from './SheetTable'
+import { baseTableData } from '../../types/tableTypes'
+
+interface TestEntry extends baseTableData {
+  name: string
+}
+
+// eslint-disable-next-line no-var
+var testMocks: {
+  mockGetRows: jest.Mock
+  mockSpreadsheet: {
+    title: string
+    sheetsByTitle: Record<string, unknown>
+    addSheet: jest.Mock
+  }
+}
+
+jest.mock('./sheetsUtil', () => {
+  const mockGetRows = jest.fn().mockResolvedValue([])
+  const mockSheet = {
+    loadHeaderRow: jest.fn().mockResolvedValue(undefined),
+    headerValues: ['_id', 'createdAt', 'lastUpdate', 'name'],
+    setHeaderRow: jest.fn().mockResolvedValue(undefined),
+    getRows: mockGetRows,
+    addRow: jest.fn().mockResolvedValue(undefined),
+  }
+  const mockSpreadsheet = {
+    title: 'Test Spreadsheet',
+    sheetsByTitle: {} as Record<string, unknown>,
+    addSheet: jest.fn().mockResolvedValue(mockSheet),
+  }
+  testMocks = { mockGetRows, mockSpreadsheet }
+  return {
+    loadSpreadsheet: jest.fn().mockResolvedValue(mockSpreadsheet),
+    limiter: { removeTokens: jest.fn().mockResolvedValue(1) },
+    parseVal: jest.fn((val: string) => {
+      try {
+        return JSON.parse(val)
+      } catch {
+        return val
+      }
+    }),
+  }
+})
+
+const spreadsheetInfo = {
+  spreadsheetId: 'test-spreadsheet-id',
+  gKey: {
+    private_key: 'test-key',
+    client_email: 'test@example.com',
+  },
+}
+
+function makeRow(id: string, name: string) {
+  return {
+    rowNumber: 2,
+    _id: JSON.stringify(id),
+    createdAt: JSON.stringify('2020-01-01'),
+    lastUpdate: JSON.stringify('2020-01-01'),
+    name: JSON.stringify(name),
+  }
+}
+
+function createTable(name: string): SheetTable<TestEntry> {
+  testMocks.mockSpreadsheet.sheetsByTitle[name] = {
+    loadHeaderRow: jest.fn().mockResolvedValue(undefined),
+    headerValues: ['_id', 'createdAt', 'lastUpdate', 'name'],
+    setHeaderRow: jest.fn().mockResolvedValue(undefined),
+    getRows: testMocks.mockGetRows,
+    addRow: jest.fn().mockResolvedValue(undefined),
+  }
+  return new SheetTable<TestEntry>(name, spreadsheetInfo, {
+    _id: 'example',
+    name: 'example',
+  })
+}
+
+describe('SheetTable.fetchAll', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    testMocks.mockGetRows.mockResolvedValue([])
+    testMocks.mockSpreadsheet.sheetsByTitle = {}
+  })
+
+  it('reloads rows from the sheet on each fetchAll call', async () => {
+    testMocks.mockGetRows.mockResolvedValue([makeRow('1', 'alpha')])
+    const table = createTable('FetchAllRefreshTable')
+    await table.loadPromise
+
+    const first = await table.fetchAll()
+    expect(first).toEqual([
+      expect.objectContaining({ _id: '1', name: 'alpha' }),
+    ])
+
+    testMocks.mockGetRows.mockResolvedValue([makeRow('1', 'beta')])
+    const second = await table.fetchAll()
+    expect(second).toEqual([
+      expect.objectContaining({ _id: '1', name: 'beta' }),
+    ])
+    expect(testMocks.mockGetRows.mock.calls.length).toBeGreaterThanOrEqual(3)
+  })
+
+  it('clears loadPromise after a fetch-triggered load', async () => {
+    testMocks.mockGetRows.mockResolvedValue([makeRow('1', 'alpha')])
+    const table = createTable('FetchAllClearPromiseTable')
+    await table.loadPromise
+
+    await table.fetchAll()
+    expect(table.loadPromise).toBeNull()
+  })
+
+  it('honors forceRefresh=false while a load is in flight', async () => {
+    let resolveRows!: (rows: ReturnType<typeof makeRow>[]) => void
+    const pendingRows = new Promise<ReturnType<typeof makeRow>[]>((resolve) => {
+      resolveRows = resolve
+    })
+    testMocks.mockGetRows.mockReturnValueOnce(pendingRows)
+
+    const table = createTable('FetchAllForceRefreshFalseTable')
+    // Constructor load is still pending; start a shared in-flight fetchAll.
+    const inFlight = table.fetchAll(false)
+    const coalesced = table.fetchAll(false)
+
+    resolveRows([makeRow('1', 'shared')])
+    const [a, b] = await Promise.all([inFlight, coalesced])
+
+    expect(a).toEqual([expect.objectContaining({ _id: '1', name: 'shared' })])
+    expect(b).toEqual([expect.objectContaining({ _id: '1', name: 'shared' })])
+    // Both calls await the in-flight constructor load; no extra reload.
+    expect(testMocks.mockGetRows).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/sheets/SheetTable.ts
+++ b/src/sheets/SheetTable.ts
@@ -140,12 +140,21 @@ export class SheetTable<T extends baseTableData> extends Table<T> {
     return this.parseRow(this.rows[index])
   }
 
-  public async fetchAll(): Promise<Array<T>> {
-    if (!this.loadPromise) {
+  public async fetchAll(forceRefresh = true): Promise<Array<T>> {
+    if (forceRefresh || !this.loadPromise) {
       this.loadPromise = this.load()
     }
-    await this.loadPromise
-    return this.toArray()
+    const loadPromise = this.loadPromise
+    try {
+      await loadPromise
+      return this.toArray()
+    } finally {
+      // Clear so a resolved promise cannot block later reloads (CMS sync).
+      // Only clear if we still own the slot — concurrent fetchAll may have replaced it.
+      if (this.loadPromise === loadPromise) {
+        this.loadPromise = null
+      }
+    }
   }
 
   public async filter(filter: (entry: T) => boolean): Promise<T[]> {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Tier
Medium

## Notion
https://app.notion.com/p/3ab55378c59381ce88f5ecd1d680d0ce

## Summary
`SheetTable.fetchAll()` only started a reload when `loadPromise` was `null`. After the first post-boot fetch, a resolved `loadPromise` stayed set forever, so later CMS/string syncs logged success but returned cached rows until restart.

## Changes
- `fetchAll(forceRefresh = true)` reloads when forced or when no load is in flight (aligned with `MongoTable`, default `true` for Sheet CMS consumers)
- Clears `loadPromise` after a fetch-triggered load (identity-checked for concurrent callers)
- Unit tests in `src/sheets/SheetTable.fetchAll.test.ts`
- Version bump to **1.1.5**

## Acceptance criteria
- [x] `SheetTable.fetchAll()` reloads from Sheets on each call (default) / when `forceRefresh === true`
- [x] `loadPromise` cleared after fetch-triggered load
- [x] Unit test: mutate mock `getRows` → second `fetchAll` returns new data
- [x] Patch version prepared for publish (`1.1.5`)
- [ ] Sunfall dependency bump + smoke (follow-up in Sunfall after Tablet publish)

## Tests
- `src/sheets/SheetTable.fetchAll.test.ts`
- `npm test` (all suites)
- `npm run lint-fix`
- `npm run tsc`

## Manual QA
Medium / backend library: unit tests cover the regression; reviewer ack on merge. After npm publish, Sunfall should bump `@wizardtower/tablet` and smoke Debug **Sync Strings** / 5‑min poll without bot restart.

## Deploy / feature flag
- Publish `@wizardtower/tablet@1.1.5`, then bump Sunfall dependency
- Feature flag: N/A

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e8f805c6-f800-4a58-8201-2c299d0b5d6f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e8f805c6-f800-4a58-8201-2c299d0b5d6f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

