### PR TITLE
fix(entity): harden saveEntity version conflict recovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.6]
+
+- Hardened `Entity.saveEntity` / `writeRecordWithMerge`: adopt current table `_version` and retry up to 5 times on conflict (recovers `undefined` vs table `1` and skew ≥2), sync `this._version` on success, and log exhausted retries.
+- Fixed falsy `_version` bump in `JsonTable.crupdate` and `MongoTable.crupdate` (`0` now increments to `1`).
+- Fixed `JsonTable` ioBuffer lost-write race with a write-generation counter so mid-flush updates are not dropped.
+- Made `JsonTable.loadTable` detect missing files via `ENOENT` `code` (more reliable than exact message match) and unref the flush interval.
+
 ## [1.1.5]
 
 - Fixed `SheetTable.fetchAll` stale cache: each call (default `forceRefresh=true`) reloads from Google Sheets and clears `loadPromise` afterward so CMS/string sync picks up live edits without restart.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@wizardtower/tablet",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@wizardtower/tablet",
-      "version": "1.1.5",
+      "version": "1.1.6",
       "license": "MIT",
       "dependencies": {
         "eslint": "^8.26.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wizardtower/tablet",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "description": "DB abstraction layer for JSON, Sheets, MongoDB, etc.",
   "main": "./built/index.js",
   "exports": {

--- a/src/Entity.saveEntity.test.ts
+++ b/src/Entity.saveEntity.test.ts
@@ -1,0 +1,140 @@
+import { mkdtempSync, rmSync } from 'fs'
+import { tmpdir } from 'os'
+import path from 'path'
+import { Entity } from './Entity'
+import { JsonTable } from './json/JsonTable'
+import { Table } from './Table'
+import { tableData } from '../types/tableTypes'
+
+interface TestRecord extends tableData {
+  name: string
+}
+
+class SaveTestEntity extends Entity<TestRecord> {
+  public name: string
+
+  constructor(id: string | undefined, name: string) {
+    super(id)
+    this.name = name
+  }
+
+  public generateRecord(): TestRecord {
+    return {
+      _id: this._id,
+      _version: this._version,
+      name: this.name,
+    }
+  }
+
+  public async save(): Promise<TestRecord | null> {
+    return this.saveEntity()
+  }
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function stopFlush(table: JsonTable<TestRecord>): void {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  clearInterval((table as any).ioBufferInterval)
+}
+
+describe('Entity.saveEntity version handling', () => {
+  let tempDir: string
+  let table: JsonTable<TestRecord>
+  let tableName: string
+
+  beforeEach(async () => {
+    Table.all.clear()
+    tempDir = mkdtempSync(path.join(tmpdir(), 'tablet-entity-'))
+    tableName = `SaveEntity_${Date.now()}_${Math.random()
+      .toString(36)
+      .slice(2)}`
+    table = new JsonTable<TestRecord>(tableName, tempDir)
+    await table.loadPromise
+    SaveTestEntity.registerEntity(table, async (record) => {
+      const entity = new SaveTestEntity(record._id, record.name)
+      entity._version = record._version
+      return entity
+    })
+  })
+
+  afterEach(() => {
+    stopFlush(table)
+    Table.all.clear()
+    rmSync(tempDir, { recursive: true, force: true })
+  })
+
+  it('persists updates when live _version is undefined but table has version 1', async () => {
+    await table.crupdate({
+      _id: 'hero-1',
+      _version: undefined,
+      name: 'initial',
+    })
+    const stored = await table.fetch('hero-1')
+    expect(stored?._version).toBe(1)
+
+    const entity = new SaveTestEntity('hero-1', 'updated')
+    entity._version = undefined
+
+    const written = await entity.save()
+
+    expect(written).not.toBeNull()
+    expect(written?.name).toBe('updated')
+    expect(written?._version).toBe(2)
+    expect(entity._version).toBe(2)
+    expect((await table.fetch('hero-1'))?.name).toBe('updated')
+  })
+
+  it('persists when live _version is behind cache by 2+ and syncs this._version', async () => {
+    await table.crupdate({
+      _id: 'hero-2',
+      _version: undefined,
+      name: 'v1',
+    })
+    // Bump cache to version 3 (two crupdates from version 1).
+    await table.crupdate({ _id: 'hero-2', _version: 1, name: 'v2' })
+    await table.crupdate({ _id: 'hero-2', _version: 2, name: 'v3' })
+    expect((await table.fetch('hero-2'))?._version).toBe(3)
+
+    const entity = new SaveTestEntity('hero-2', 'recovered')
+    entity._version = 1
+
+    const written = await entity.save()
+
+    expect(written).not.toBeNull()
+    expect(written?.name).toBe('recovered')
+    expect(written?._version).toBe(4)
+    expect(entity._version).toBe(written?._version)
+  })
+
+  it('returns null and logs after exhausted version retries', async () => {
+    const errorSpy = jest
+      .spyOn(console, 'error')
+      .mockImplementation(() => undefined)
+
+    const conflictTable = {
+      crupdate: jest.fn().mockResolvedValue(false),
+      fetch: jest.fn().mockResolvedValue({
+        _id: 'hero-3',
+        _version: 9,
+        name: 'stale',
+      }),
+    }
+
+    const entity = new SaveTestEntity('hero-3', 'lost')
+    entity._version = 1
+    jest.spyOn(entity, 'writeRecordWithMerge').mockImplementation(async () => {
+      return Entity.prototype.writeRecordWithMerge.call(
+        entity,
+        conflictTable as unknown as JsonTable<TestRecord>,
+        entity.generateRecord()
+      )
+    })
+
+    const written = await entity.save()
+
+    expect(written).toBeNull()
+    expect(conflictTable.crupdate).toHaveBeenCalledTimes(5)
+    expect(errorSpy).toHaveBeenCalled()
+    errorSpy.mockRestore()
+  })
+})

--- a/src/Entity.ts
+++ b/src/Entity.ts
@@ -204,33 +204,61 @@ export abstract class Entity<T extends baseTableData> implements baseTableData {
     else return null
   }
 
+  private static readonly MAX_VERSION_RETRIES = 5
+
   async writeRecordWithMerge<T extends baseTableData>(
     table: Table<T>,
     record: T & { _version?: number }, // if tableData is used as T, there will be a version
     mergeFunction?: (newVal: T, oldVal: T) => T
   ): Promise<T | false> {
-    const writtenRecord = await table.crupdate(record)
-    if (writtenRecord) {
-      return writtenRecord
-    }
-
-    if (mergeFunction) {
-      // fetch the current value in the db (bypass cache)
-      const existingRecord = await table.fetch(this._id, true)
-
-      // merge with existing entity if it exists
-      if (existingRecord) {
-        const mergedRecord = mergeFunction(record, existingRecord)
-        const mergedSavedRecord = await table.crupdate(mergedRecord)
-        return mergedSavedRecord
+    let lastExistingVersion: number | undefined
+    for (let attempt = 0; attempt < Entity.MAX_VERSION_RETRIES; attempt++) {
+      const writtenRecord = await table.crupdate(record)
+      if (writtenRecord) {
+        return writtenRecord
       }
-    } else if (record._version !== undefined) {
-      // if no merge function, increment the version and try again to preserve existing functionality
-      record._version = record._version + 1
-      const retryRecord = await table.crupdate(record)
-      return retryRecord
+
+      // Conflict: adopt the table's current version and retry (covers undefined
+      // live _version vs table 1, and skew of 2+). Do not coerce undefined→0
+      // up front — MongoTable treats undefined as unversioned upsert.
+      const existingRecord = (await table.fetch(this._id, true)) as
+        | (T & { _version?: number })
+        | null
+      if (!existingRecord) {
+        break
+      }
+      lastExistingVersion = existingRecord._version
+
+      if (mergeFunction) {
+        const mergedRecord = mergeFunction(record, existingRecord) as T & {
+          _version?: number
+        }
+        mergedRecord._version = existingRecord._version
+        const mergedSavedRecord = await table.crupdate(mergedRecord)
+        if (mergedSavedRecord) {
+          return mergedSavedRecord
+        }
+        const latest = (await table.fetch(this._id, true)) as
+          | (T & { _version?: number })
+          | null
+        if (!latest) {
+          break
+        }
+        lastExistingVersion = latest._version
+        record._version = latest._version
+        continue
+      }
+
+      record._version = existingRecord._version
     }
 
+    console.error(
+      `TABLET_ENTITY.writeRecordWithMerge: exhausted retries for ${
+        Entity.ctorOf(this).name
+      } _id=${this._id} attempted _version=${
+        record._version
+      } existing _version=${lastExistingVersion}`
+    )
     return false
   }
 
@@ -254,11 +282,18 @@ export abstract class Entity<T extends baseTableData> implements baseTableData {
 
     // update cache with new entity and return result
     if (writtenRecord) {
+      const savedVersion = (writtenRecord as T & { _version?: number })._version
+      if (savedVersion !== undefined) {
+        this._version = savedVersion
+      }
       const cache = Entity.findCache(ctor)
       cache.set(this._id, this)
       return writtenRecord
     }
 
+    console.error(
+      `TABLET_ENTITY.saveEntity: failed to save ${ctor.name} _id=${this._id} live _version=${this._version}`
+    )
     return null
   }
 

--- a/src/json/JsonTable.test.ts
+++ b/src/json/JsonTable.test.ts
@@ -1,0 +1,86 @@
+import { mkdtempSync, rmSync } from 'fs'
+import { tmpdir } from 'os'
+import path from 'path'
+import { JsonTable } from './JsonTable'
+import { Table } from '../Table'
+import { tableData } from '../../types/tableTypes'
+
+interface TestEntry extends tableData {
+  name: string
+}
+
+// Access private flush fields for race coverage without widening production API.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function internals(table: JsonTable<TestEntry>): any {
+  return table
+}
+
+describe('JsonTable.crupdate and ioBuffer', () => {
+  let tempDir: string
+
+  beforeEach(() => {
+    Table.all.clear()
+    tempDir = mkdtempSync(path.join(tmpdir(), 'tablet-json-'))
+  })
+
+  afterEach(() => {
+    Table.all.clear()
+    rmSync(tempDir, { recursive: true, force: true })
+  })
+
+  it('treats _version 0 as present and bumps to 1', async () => {
+    const table = new JsonTable<TestEntry>('VersionZero', tempDir)
+    await table.loadPromise
+    clearInterval(internals(table).ioBufferInterval)
+
+    const result = await table.crupdate({
+      _id: 'a',
+      _version: 0,
+      name: 'zero',
+    })
+
+    expect(result).toEqual(
+      expect.objectContaining({ _id: 'a', _version: 1, name: 'zero' })
+    )
+  })
+
+  it('keeps bufferWrite true when a write lands during flush', async () => {
+    const table = new JsonTable<TestEntry>('FlushRace', tempDir)
+    await table.loadPromise
+    const t = internals(table)
+    clearInterval(t.ioBufferInterval)
+
+    await table.crupdate({
+      _id: 'a',
+      _version: undefined,
+      name: 'first',
+    })
+    expect(t.bufferWrite).toBe(true)
+    const generationBeforeFlush = t.writeGeneration
+
+    let resolveSave!: () => void
+    const saveGate = new Promise<void>((resolve) => {
+      resolveSave = resolve
+    })
+    const originalSave = t.saveTable.bind(table)
+    jest.spyOn(t, 'saveTable').mockImplementation(async () => {
+      await saveGate
+      return originalSave()
+    })
+
+    t.ioBuffer()
+    // Mid-flush write bumps generation while save is still in flight.
+    await table.crupdate({
+      _id: 'a',
+      _version: 1,
+      name: 'second',
+    })
+    expect(t.writeGeneration).toBeGreaterThan(generationBeforeFlush)
+
+    resolveSave()
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(t.bufferWrite).toBe(true)
+  })
+})

--- a/src/json/JsonTable.ts
+++ b/src/json/JsonTable.ts
@@ -30,6 +30,7 @@ class JsonTable<T extends tableData> extends Table<T> {
   public readonly filePath: PathLike
   private cache: Map<string, T> = new Map<string, T>()
   private bufferWrite = false
+  private writeGeneration = 0
   private ioBufferInterval = setInterval(() => this.ioBuffer(), 1000)
   /**
    *
@@ -42,6 +43,9 @@ class JsonTable<T extends tableData> extends Table<T> {
     this.filePath = path.join(this.dirPath.toString(), name + fileExt)
     this.summary['FILE'] = { value: this.filePath.toString() }
     this.loadPromise = this.loadTable()
+    if (typeof this.ioBufferInterval.unref === 'function') {
+      this.ioBufferInterval.unref()
+    }
   }
   /**
    * @returns how many entries are in this table
@@ -131,10 +135,11 @@ class JsonTable<T extends tableData> extends Table<T> {
 
     const updatedEntry: T = {
       ...entry,
-      _version: entry._version ? entry._version + 1 : 1,
+      _version: entry._version != null ? entry._version + 1 : 1,
     }
 
     this.cache.set(entry._id, updatedEntry)
+    this.writeGeneration++
     this.bufferWrite = true
     this.summary.UPDATES.value++
     return updatedEntry
@@ -166,16 +171,23 @@ class JsonTable<T extends tableData> extends Table<T> {
    */
   public async delete(entry: T) {
     const res = this.cache.delete(entry._id)
+    this.writeGeneration++
     this.bufferWrite = true
     return res
   }
 
   private ioBuffer() {
-    if (this.bufferWrite) {
-      this.saveTable()
-        .then(() => (this.bufferWrite = false))
-        .catch((err) => console.log(err))
-    }
+    if (!this.bufferWrite) return
+    const generationAtStart = this.writeGeneration
+    this.saveTable()
+      .then(() => {
+        // Only clear when no writes landed during the flush; otherwise keep
+        // bufferWrite so the next interval persists the newer cache state.
+        if (this.writeGeneration === generationAtStart) {
+          this.bufferWrite = false
+        }
+      })
+      .catch((err) => console.log(err))
   }
 
   private async saveTable() {
@@ -211,17 +223,16 @@ class JsonTable<T extends tableData> extends Table<T> {
 
       return true
     } catch (err) {
+      const errno = err as NodeJS.ErrnoException
+      if (errno?.code === 'ENOENT') {
+        if (this.retries > 3)
+          throw `TABLET_ERROR: JsonTable.load failed after ${this.retries} attempts`
+        this.retries++
+        await this.saveTable()
+        return this.loadTable()
+      }
       if (err instanceof Error) {
-        if (
-          err.message ==
-          `ENOENT: no such file or directory, open '${this.filePath}'`
-        ) {
-          if (this.retries > 3)
-            throw `TABLET_ERROR: JsonTable.load failed after ${this.retries} attempts`
-          this.retries++
-          await this.saveTable()
-          return this.loadTable()
-        } else if (err.name.substring(0, 11) == 'SyntaxError') {
+        if (err.name.substring(0, 11) == 'SyntaxError') {
           throw `TABLET_ERROR: JSONTABLE FILE ${this.filePath} IS INCORRECTLY FORMATTED`
         } else {
           console.log(err.message.substring(0, 10))

--- a/src/mongodb/MongoTable.crupdate.test.ts
+++ b/src/mongodb/MongoTable.crupdate.test.ts
@@ -96,4 +96,26 @@ describe('MongoTable.crupdate', () => {
       { upsert: false, returnDocument: 'after' }
     )
   })
+
+  it('bumps _version 0 to 1 instead of treating 0 as missing', async () => {
+    const table = createTable('VersionZero')
+    await table.loadPromise
+
+    const entry: TestEntry = {
+      _id: 'player-4',
+      name: 'Dee',
+      _version: 0,
+    }
+    const saved: TestEntry = { ...entry, _version: 1 }
+    mockFindOneAndUpdate.mockResolvedValue(saved)
+
+    const result = await table.crupdate(entry)
+
+    expect(result).toEqual(saved)
+    expect(mockFindOneAndUpdate).toHaveBeenCalledWith(
+      { _id: 'player-4', _version: 0 },
+      { $set: { name: 'Dee', _version: 1 } },
+      { upsert: false, returnDocument: 'after' }
+    )
+  })
 })

--- a/src/mongodb/MongoTable.ts
+++ b/src/mongodb/MongoTable.ts
@@ -53,7 +53,7 @@ class MongoTable<T extends tableData> extends Table<T> {
           _version: entry._version,
         } as Filter<T>)
       : ({ _id } as Filter<T>)
-    const newVersion = entry._version ? entry._version + 1 : 1
+    const newVersion = entry._version != null ? entry._version + 1 : 1
     const result = await this.collection.findOneAndUpdate(
       filter,
       {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Tier
Medium

## Notion
https://app.notion.com/p/3ab55378c5938184975afbf8da7ac206

## Summary
Sunfall inventory/mail saves could succeed in memory while `saveEntity()` returned `null` when live `_version` was `undefined` or behind the table cache by more than one. This hardens Tablet so version conflicts are recovered with a bounded adopt-and-retry loop, the entity’s `_version` is synced on success, failures are logged, and JsonTable mid-flush writes are not dropped.

Follow-up to SheetTable work ([#19](https://github.com/Arcane-Laboratory/Tablet/pull/19)); tracks [Tablet #20](https://github.com/Arcane-Laboratory/Tablet/issues/20).

## Changes
- `Entity.writeRecordWithMerge`: up to 5 retries; on conflict adopt current table `_version` (optional merge path preserved)
- `Entity.saveEntity`: sync `this._version` from written record; log on failure
- `JsonTable` / `MongoTable` crupdate: `_version != null` bump so `0` → `1`
- `JsonTable` ioBuffer: write-generation counter avoids clearing `bufferWrite` after mid-flush updates
- `JsonTable.loadTable`: detect missing file via `ENOENT` code; unref flush interval
- Version **1.1.6** (1.1.5 reserved for #19)

## Acceptance criteria
- [x] `_version === undefined` after table has `1` persists updates (not silent `null`)
- [x] Live `_version` behind cache by 2+ still persists within retry bound
- [x] After success, `entity._version === writtenRecord._version`
- [x] Exhausted retries are logged (no throw; API stays `null`/`false`)
- [x] Concurrent `crupdate` during JSON flush does not drop durable updates
- [ ] Publish + Sunfall dep bump / drop redundant workarounds (post-merge)

## Tests
- `src/Entity.saveEntity.test.ts`
- `src/json/JsonTable.test.ts`
- `src/mongodb/MongoTable.crupdate.test.ts` (adds `_version: 0` case)
- `npm test`, `npm run lint-fix`, `npm run tsc`

## Manual QA
Medium library: unit tests + reviewer ack. After publish, Sunfall should bump `@wizardtower/tablet` and smoke inventory/mail persist (Mel / Echoing Halls) under concurrent grants.

## Deploy / feature flag
- Publish `@wizardtower/tablet@1.1.6`, then bump Sunfall
- Feature flag: N/A
- P2 (`hydrateFromRecord` / docs anti-pattern) left for a later slice

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e8f805c6-f800-4a58-8201-2c299d0b5d6f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e8f805c6-f800-4a58-8201-2c299d0b5d6f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

