### PR TITLE
fix(deps): upgrade google-spreadsheet to v5 (remove axios vuln)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Upgraded `google-spreadsheet` from v3 to v5 (and added peer `google-auth-library`) to remove the vulnerable transitive `axios` dependency. Sheet auth now uses `JWT` service-account credentials; row field access uses `get`/`set`.
+
 ## [1.1.6]
 
 - Hardened `Entity.saveEntity` / `writeRecordWithMerge`: adopt current table `_version` and retry up to 5 times on conflict (recovers `undefined` vs table `1` and skew ≥2), sync `this._version` on success, and log exhausted retries.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.6]
+
+- Hardened `Entity.saveEntity` / `writeRecordWithMerge`: adopt current table `_version` and retry up to 5 times on conflict (recovers `undefined` vs table `1` and skew ≥2), sync `this._version` on success, and log exhausted retries.
+- Fixed falsy `_version` bump in `JsonTable.crupdate` and `MongoTable.crupdate` (`0` now increments to `1`).
+- Fixed `JsonTable` ioBuffer lost-write race with a write-generation counter so mid-flush updates are not dropped.
+- Made `JsonTable.loadTable` detect missing files via `ENOENT` `code` (more reliable than exact message match) and unref the flush interval.
+
 ## [1.1.4]
 
 - Fixed `MongoTable.crupdate` for MongoDB Node driver 6.x: wrap updates in `$set` for `findOneAndUpdate`, fixing `MongoInvalidArgumentError: Update document requires atomic operators` on save.

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
       "license": "MIT",
       "dependencies": {
         "eslint": "^8.26.0",
-        "google-spreadsheet": "^3.3.0",
+        "google-auth-library": "^10.9.1",
+        "google-spreadsheet": "^5.3.0",
         "json-stable-stringify": "^1.0.2",
         "limiter": "^2.1.0",
         "mongodb": "^6.5.0"
@@ -1540,17 +1541,6 @@
       "deprecated": "Use your platform's native atob() and btoa() methods instead",
       "dev": true
     },
-    "node_modules/abort-controller": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
-      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
-      "dependencies": {
-        "event-target-shim": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=6.5"
-      }
-    },
     "node_modules/acorn": {
       "version": "8.11.3",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.3.tgz",
@@ -1607,6 +1597,7 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
       "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "devOptional": true,
       "dependencies": {
         "debug": "4"
       },
@@ -1715,27 +1706,11 @@
         "node": ">=8"
       }
     },
-    "node_modules/arrify": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/arrify/-/arrify-2.0.1.tgz",
-      "integrity": "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
       "dev": true
-    },
-    "node_modules/axios": {
-      "version": "0.21.4",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
-      "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
-      "dependencies": {
-        "follow-redirects": "^1.14.0"
-      }
     },
     "node_modules/babel-jest": {
       "version": "27.5.1",
@@ -1956,7 +1931,8 @@
     "node_modules/buffer-equal-constant-time": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
-      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA=="
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/buffer-from": {
       "version": "1.1.2",
@@ -2193,6 +2169,15 @@
       "integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg==",
       "dev": true
     },
+    "node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/data-urls": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-2.0.0.tgz",
@@ -2366,6 +2351,7 @@
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
       "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
       "dependencies": {
         "safe-buffer": "^5.0.1"
       }
@@ -2447,6 +2433,17 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/es-toolkit": {
+      "version": "1.50.0",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.50.0.tgz",
+      "integrity": "sha512-OyZKhUVvEep9ITEiwHn8GKnMRQIVqoSIX7WnRbkWgJkllCujilqP2rD0u979tkl8wqyc8ICwlc1UBVv/Sl1G6w==",
+      "license": "MIT",
+      "workspaces": [
+        "docs",
+        "benchmarks",
+        "tests/types"
+      ]
     },
     "node_modules/escalade": {
       "version": "3.1.2",
@@ -2760,14 +2757,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/event-target-shim": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
-      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/execa": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
@@ -2872,11 +2861,6 @@
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true
     },
-    "node_modules/fast-text-encoding": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/fast-text-encoding/-/fast-text-encoding-1.0.6.tgz",
-      "integrity": "sha512-VhXlQgj9ioXCqGstD37E/HBeqEGV/qOD/kmbVG8h5xKBYvM1L3lR1Zn4555cQ8GkYbJa8aJSipLPndE1k6zK2w=="
-    },
     "node_modules/fastq": {
       "version": "1.17.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.17.1.tgz",
@@ -2893,6 +2877,29 @@
       "dev": true,
       "dependencies": {
         "bser": "2.1.1"
+      }
+    },
+    "node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
       }
     },
     "node_modules/file-entry-cache": {
@@ -2956,26 +2963,6 @@
       "integrity": "sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw==",
       "dev": true
     },
-    "node_modules/follow-redirects": {
-      "version": "1.15.9",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
-      "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://github.com/sponsors/RubenVerborgh"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=4.0"
-      },
-      "peerDependenciesMeta": {
-        "debug": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/form-data": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.4.tgz",
@@ -2991,6 +2978,18 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "license": "MIT",
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
       }
     },
     "node_modules/fs.realpath": {
@@ -3022,18 +3021,57 @@
       }
     },
     "node_modules/gaxios": {
-      "version": "4.3.3",
-      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-4.3.3.tgz",
-      "integrity": "sha512-gSaYYIO1Y3wUtdfHmjDUZ8LWaxJQpiavzbF5Kq53akSzvmVg0RfyOcFDbO1KJ/KCGRFz2qG+lS81F0nkr7cRJA==",
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.3.0.tgz",
+      "integrity": "sha512-RB5vLV+vvQeoFPCX4QMK6/hjVkbIamPp1QSUD0CiZcnj12qbpiL+pLbYtgD+oZkWl0tl9z+o2Utp+MpM3QRhBA==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "abort-controller": "^3.0.0",
         "extend": "^3.0.2",
-        "https-proxy-agent": "^5.0.0",
-        "is-stream": "^2.0.0",
-        "node-fetch": "^2.6.7"
+        "https-proxy-agent": "^7.0.1",
+        "node-fetch": "^3.3.2"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=18"
+      }
+    },
+    "node_modules/gaxios/node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/gaxios/node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/gaxios/node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "license": "MIT",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
       }
     },
     "node_modules/gcp-metadata": {
@@ -3210,61 +3248,61 @@
       }
     },
     "node_modules/google-auth-library": {
-      "version": "6.1.6",
-      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-6.1.6.tgz",
-      "integrity": "sha512-Q+ZjUEvLQj/lrVHF/IQwRo6p3s8Nc44Zk/DALsN+ac3T4HY/g/3rrufkgtl+nZ1TW7DNAw5cTChdVp4apUXVgQ==",
+      "version": "10.9.1",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.9.1.tgz",
+      "integrity": "sha512-i1ydyHrqcIxXkWh/uBmVkzCvIuq5yiK2ATndIe5XxKholrG/MTYP9xGYka4sQhrbIAgGjL2B6NOE7rFaiF3fXw==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "arrify": "^2.0.0",
         "base64-js": "^1.3.0",
         "ecdsa-sig-formatter": "^1.0.11",
-        "fast-text-encoding": "^1.0.0",
-        "gaxios": "^4.0.0",
-        "gcp-metadata": "^4.2.0",
-        "gtoken": "^5.0.4",
-        "jws": "^4.0.0",
-        "lru-cache": "^6.0.0"
+        "gaxios": "^7.1.4",
+        "gcp-metadata": "8.1.2",
+        "google-logging-utils": "1.1.3",
+        "jws": "^4.0.0"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=18"
       }
     },
     "node_modules/google-auth-library/node_modules/gcp-metadata": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-4.3.1.tgz",
-      "integrity": "sha512-x850LS5N7V1F3UcV7PoupzGsyD6iVwTVvsh3tbXfkctZnBnjW5yu5z1/3k3SehF7TyoTIe78rJs02GMMy+LF+A==",
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-8.1.2.tgz",
+      "integrity": "sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "gaxios": "^4.0.0",
+        "gaxios": "^7.0.0",
+        "google-logging-utils": "^1.0.0",
         "json-bigint": "^1.0.0"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=18"
       }
     },
-    "node_modules/google-p12-pem": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/google-p12-pem/-/google-p12-pem-3.1.4.tgz",
-      "integrity": "sha512-HHuHmkLgwjdmVRngf5+gSmpkyaRI6QmOg77J8tkNBHhNEI62sGHyw4/+UkgyZEI7h84NbWprXDJ+sa3xOYFvTg==",
-      "dependencies": {
-        "node-forge": "^1.3.1"
-      },
-      "bin": {
-        "gp12-pem": "build/src/bin/gp12-pem.js"
-      },
+    "node_modules/google-logging-utils": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-1.1.3.tgz",
+      "integrity": "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==",
+      "license": "Apache-2.0",
       "engines": {
-        "node": ">=10"
+        "node": ">=14"
       }
     },
     "node_modules/google-spreadsheet": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/google-spreadsheet/-/google-spreadsheet-3.3.0.tgz",
-      "integrity": "sha512-ahmRNh14s1i3phfvbF2mxen1lohWJpUaFWgsU6P6bXu7QrmxMaim1Ys/7BU4W5yucWCzphoIrHMbrbeIR5K9mw==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/google-spreadsheet/-/google-spreadsheet-5.3.0.tgz",
+      "integrity": "sha512-hsMI2hc1aqDgZsfOEvJ+M4vwH6h8OuXKdxwKPPQq/OKs2dYnuaD8qx3GtiPyYcXRSN60j7EHbaHBPihOhzwY/A==",
+      "license": "MIT",
       "dependencies": {
-        "axios": "^0.21.4",
-        "google-auth-library": "^6.1.3",
-        "lodash": "^4.17.21"
+        "es-toolkit": "^1.47.0",
+        "ky": "^2.0.2"
       },
-      "engines": {
-        "node": ">=0.8.0"
+      "peerDependencies": {
+        "google-auth-library": ">=8.8.0"
+      },
+      "peerDependenciesMeta": {
+        "google-auth-library": {
+          "optional": true
+        }
       }
     },
     "node_modules/gopd": {
@@ -3290,19 +3328,6 @@
       "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
       "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
       "dev": true
-    },
-    "node_modules/gtoken": {
-      "version": "5.3.2",
-      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-5.3.2.tgz",
-      "integrity": "sha512-gkvEKREW7dXWF8NV8pVrKfW7WqReAmjjkMBh6lNCCGOM4ucS0r0YyXXl0r/9Yj8wcW/32ISkfc8h5mPTDbtifQ==",
-      "dependencies": {
-        "gaxios": "^4.0.0",
-        "google-p12-pem": "^3.1.3",
-        "jws": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
     },
     "node_modules/has-flag": {
       "version": "4.0.0",
@@ -3400,6 +3425,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
       "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "devOptional": true,
       "dependencies": {
         "agent-base": "6",
         "debug": "4"
@@ -3584,6 +3610,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
       "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "devOptional": true,
       "engines": {
         "node": ">=8"
       },
@@ -4448,21 +4475,23 @@
       "integrity": "sha512-L7RjvtJsL0QO8xFs5wEoDDzzJwoiowRw6Rn/GnvldlchS2JQr9wFYPiwZcDfrbbujEKqKN0tvENdbjXdYhDp5Q=="
     },
     "node_modules/jwa": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.0.tgz",
-      "integrity": "sha512-jrZ2Qx916EA+fq9cEAeCROWPTfCwi1IVHqT2tapuqLEVVDKFDENFw1oL+MwrTvH6msKxsd1YTDVw6uKEcsrLEA==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "license": "MIT",
       "dependencies": {
-        "buffer-equal-constant-time": "1.0.1",
+        "buffer-equal-constant-time": "^1.0.1",
         "ecdsa-sig-formatter": "1.0.11",
         "safe-buffer": "^5.0.1"
       }
     },
     "node_modules/jws": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.0.tgz",
-      "integrity": "sha512-KDncfTmOZoOMTFG4mBlG0qUIOlc03fmzH+ru6RgYVZhPkyiy/92Owlt/8UEN+a4TXR1FQetfIpJE8ApdvdVxTg==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "license": "MIT",
       "dependencies": {
-        "jwa": "^2.0.0",
+        "jwa": "^2.0.1",
         "safe-buffer": "^5.0.1"
       }
     },
@@ -4482,6 +4511,18 @@
       "dev": true,
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/ky": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/ky/-/ky-2.0.2.tgz",
+      "integrity": "sha512-/GmXpo9F9W+f8n4Ivr2iH+7h7wL7jLbLKWkMlpflcCRb6kGjBfTlASEXaZ9qUgNTn4VgS0P2pwxxzQ4EM6Ulgg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=22"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/ky?sponsor=1"
       }
     },
     "node_modules/leven": {
@@ -4538,7 +4579,8 @@
     "node_modules/lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "dev": true
     },
     "node_modules/lodash.memoize": {
       "version": "4.1.2",
@@ -4556,6 +4598,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -4780,10 +4823,32 @@
       "integrity": "sha512-Tj+HTDSJJKaZnfiuw+iaF9skdPpTo2GtEly5JHnWV/hfv2Qj/9RKsGISQtLh2ox3l5EAGw487hnBee0sIJ6v2g==",
       "dev": true
     },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
     "node_modules/node-fetch": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
       "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "whatwg-url": "^5.0.0"
       },
@@ -4802,28 +4867,26 @@
     "node_modules/node-fetch/node_modules/tr46": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "optional": true,
+      "peer": true
     },
     "node_modules/node-fetch/node_modules/webidl-conversions": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "optional": true,
+      "peer": true
     },
     "node_modules/node-fetch/node_modules/whatwg-url": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
       "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"
-      }
-    },
-    "node_modules/node-forge": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.1.tgz",
-      "integrity": "sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==",
-      "engines": {
-        "node": ">= 6.13.0"
       }
     },
     "node_modules/node-int64": {
@@ -5389,7 +5452,8 @@
           "type": "consulting",
           "url": "https://feross.org/support"
         }
-      ]
+      ],
+      "license": "MIT"
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
@@ -6105,6 +6169,15 @@
         "makeerror": "1.0.12"
       }
     },
+    "node_modules/web-streams-polyfill": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/webidl-conversions": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-6.1.0.tgz",
@@ -6239,7 +6312,8 @@
     "node_modules/yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
     },
     "node_modules/yargs": {
       "version": "16.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@wizardtower/tablet",
-  "version": "1.1.4",
+  "version": "1.1.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@wizardtower/tablet",
-      "version": "1.1.4",
+      "version": "1.1.6",
       "license": "MIT",
       "dependencies": {
         "eslint": "^8.26.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wizardtower/tablet",
-  "version": "1.1.4",
+  "version": "1.1.6",
   "description": "DB abstraction layer for JSON, Sheets, MongoDB, etc.",
   "main": "./built/index.js",
   "exports": {

--- a/package.json
+++ b/package.json
@@ -41,10 +41,10 @@
     "@typescript-eslint/eslint-plugin": "^5.5.0",
     "@typescript-eslint/parser": "^5.5.0",
     "eslint": "^8.0.0",
-    "jest": "^27.5.1",
     "eslint-config-prettier": "^8.5.0",
     "eslint-plugin-etc": "^2.0.2",
     "eslint-plugin-prettier": "^4.2.1",
+    "jest": "^27.5.1",
     "prettier": "^2.7.1",
     "ts-jest": "^27.1.0",
     "ts-node": "^10.8.1",
@@ -52,7 +52,8 @@
   },
   "dependencies": {
     "eslint": "^8.26.0",
-    "google-spreadsheet": "^3.3.0",
+    "google-auth-library": "^10.9.1",
+    "google-spreadsheet": "^5.3.0",
     "json-stable-stringify": "^1.0.2",
     "limiter": "^2.1.0",
     "mongodb": "^6.5.0"

--- a/src/Entity.saveEntity.test.ts
+++ b/src/Entity.saveEntity.test.ts
@@ -1,0 +1,140 @@
+import { mkdtempSync, rmSync } from 'fs'
+import { tmpdir } from 'os'
+import path from 'path'
+import { Entity } from './Entity'
+import { JsonTable } from './json/JsonTable'
+import { Table } from './Table'
+import { tableData } from '../types/tableTypes'
+
+interface TestRecord extends tableData {
+  name: string
+}
+
+class SaveTestEntity extends Entity<TestRecord> {
+  public name: string
+
+  constructor(id: string | undefined, name: string) {
+    super(id)
+    this.name = name
+  }
+
+  public generateRecord(): TestRecord {
+    return {
+      _id: this._id,
+      _version: this._version,
+      name: this.name,
+    }
+  }
+
+  public async save(): Promise<TestRecord | null> {
+    return this.saveEntity()
+  }
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function stopFlush(table: JsonTable<TestRecord>): void {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  clearInterval((table as any).ioBufferInterval)
+}
+
+describe('Entity.saveEntity version handling', () => {
+  let tempDir: string
+  let table: JsonTable<TestRecord>
+  let tableName: string
+
+  beforeEach(async () => {
+    Table.all.clear()
+    tempDir = mkdtempSync(path.join(tmpdir(), 'tablet-entity-'))
+    tableName = `SaveEntity_${Date.now()}_${Math.random()
+      .toString(36)
+      .slice(2)}`
+    table = new JsonTable<TestRecord>(tableName, tempDir)
+    await table.loadPromise
+    SaveTestEntity.registerEntity(table, async (record) => {
+      const entity = new SaveTestEntity(record._id, record.name)
+      entity._version = record._version
+      return entity
+    })
+  })
+
+  afterEach(() => {
+    stopFlush(table)
+    Table.all.clear()
+    rmSync(tempDir, { recursive: true, force: true })
+  })
+
+  it('persists updates when live _version is undefined but table has version 1', async () => {
+    await table.crupdate({
+      _id: 'hero-1',
+      _version: undefined,
+      name: 'initial',
+    })
+    const stored = await table.fetch('hero-1')
+    expect(stored?._version).toBe(1)
+
+    const entity = new SaveTestEntity('hero-1', 'updated')
+    entity._version = undefined
+
+    const written = await entity.save()
+
+    expect(written).not.toBeNull()
+    expect(written?.name).toBe('updated')
+    expect(written?._version).toBe(2)
+    expect(entity._version).toBe(2)
+    expect((await table.fetch('hero-1'))?.name).toBe('updated')
+  })
+
+  it('persists when live _version is behind cache by 2+ and syncs this._version', async () => {
+    await table.crupdate({
+      _id: 'hero-2',
+      _version: undefined,
+      name: 'v1',
+    })
+    // Bump cache to version 3 (two crupdates from version 1).
+    await table.crupdate({ _id: 'hero-2', _version: 1, name: 'v2' })
+    await table.crupdate({ _id: 'hero-2', _version: 2, name: 'v3' })
+    expect((await table.fetch('hero-2'))?._version).toBe(3)
+
+    const entity = new SaveTestEntity('hero-2', 'recovered')
+    entity._version = 1
+
+    const written = await entity.save()
+
+    expect(written).not.toBeNull()
+    expect(written?.name).toBe('recovered')
+    expect(written?._version).toBe(4)
+    expect(entity._version).toBe(written?._version)
+  })
+
+  it('returns null and logs after exhausted version retries', async () => {
+    const errorSpy = jest
+      .spyOn(console, 'error')
+      .mockImplementation(() => undefined)
+
+    const conflictTable = {
+      crupdate: jest.fn().mockResolvedValue(false),
+      fetch: jest.fn().mockResolvedValue({
+        _id: 'hero-3',
+        _version: 9,
+        name: 'stale',
+      }),
+    }
+
+    const entity = new SaveTestEntity('hero-3', 'lost')
+    entity._version = 1
+    jest.spyOn(entity, 'writeRecordWithMerge').mockImplementation(async () => {
+      return Entity.prototype.writeRecordWithMerge.call(
+        entity,
+        conflictTable as unknown as JsonTable<TestRecord>,
+        entity.generateRecord()
+      )
+    })
+
+    const written = await entity.save()
+
+    expect(written).toBeNull()
+    expect(conflictTable.crupdate).toHaveBeenCalledTimes(5)
+    expect(errorSpy).toHaveBeenCalled()
+    errorSpy.mockRestore()
+  })
+})

--- a/src/Entity.ts
+++ b/src/Entity.ts
@@ -204,33 +204,61 @@ export abstract class Entity<T extends baseTableData> implements baseTableData {
     else return null
   }
 
+  private static readonly MAX_VERSION_RETRIES = 5
+
   async writeRecordWithMerge<T extends baseTableData>(
     table: Table<T>,
     record: T & { _version?: number }, // if tableData is used as T, there will be a version
     mergeFunction?: (newVal: T, oldVal: T) => T
   ): Promise<T | false> {
-    const writtenRecord = await table.crupdate(record)
-    if (writtenRecord) {
-      return writtenRecord
-    }
-
-    if (mergeFunction) {
-      // fetch the current value in the db (bypass cache)
-      const existingRecord = await table.fetch(this._id, true)
-
-      // merge with existing entity if it exists
-      if (existingRecord) {
-        const mergedRecord = mergeFunction(record, existingRecord)
-        const mergedSavedRecord = await table.crupdate(mergedRecord)
-        return mergedSavedRecord
+    let lastExistingVersion: number | undefined
+    for (let attempt = 0; attempt < Entity.MAX_VERSION_RETRIES; attempt++) {
+      const writtenRecord = await table.crupdate(record)
+      if (writtenRecord) {
+        return writtenRecord
       }
-    } else if (record._version !== undefined) {
-      // if no merge function, increment the version and try again to preserve existing functionality
-      record._version = record._version + 1
-      const retryRecord = await table.crupdate(record)
-      return retryRecord
+
+      // Conflict: adopt the table's current version and retry (covers undefined
+      // live _version vs table 1, and skew of 2+). Do not coerce undefined→0
+      // up front — MongoTable treats undefined as unversioned upsert.
+      const existingRecord = (await table.fetch(this._id, true)) as
+        | (T & { _version?: number })
+        | null
+      if (!existingRecord) {
+        break
+      }
+      lastExistingVersion = existingRecord._version
+
+      if (mergeFunction) {
+        const mergedRecord = mergeFunction(record, existingRecord) as T & {
+          _version?: number
+        }
+        mergedRecord._version = existingRecord._version
+        const mergedSavedRecord = await table.crupdate(mergedRecord)
+        if (mergedSavedRecord) {
+          return mergedSavedRecord
+        }
+        const latest = (await table.fetch(this._id, true)) as
+          | (T & { _version?: number })
+          | null
+        if (!latest) {
+          break
+        }
+        lastExistingVersion = latest._version
+        record._version = latest._version
+        continue
+      }
+
+      record._version = existingRecord._version
     }
 
+    console.error(
+      `TABLET_ENTITY.writeRecordWithMerge: exhausted retries for ${
+        Entity.ctorOf(this).name
+      } _id=${this._id} attempted _version=${
+        record._version
+      } existing _version=${lastExistingVersion}`
+    )
     return false
   }
 
@@ -254,11 +282,18 @@ export abstract class Entity<T extends baseTableData> implements baseTableData {
 
     // update cache with new entity and return result
     if (writtenRecord) {
+      const savedVersion = (writtenRecord as T & { _version?: number })._version
+      if (savedVersion !== undefined) {
+        this._version = savedVersion
+      }
       const cache = Entity.findCache(ctor)
       cache.set(this._id, this)
       return writtenRecord
     }
 
+    console.error(
+      `TABLET_ENTITY.saveEntity: failed to save ${ctor.name} _id=${this._id} live _version=${this._version}`
+    )
     return null
   }
 

--- a/src/json/JsonTable.test.ts
+++ b/src/json/JsonTable.test.ts
@@ -1,0 +1,86 @@
+import { mkdtempSync, rmSync } from 'fs'
+import { tmpdir } from 'os'
+import path from 'path'
+import { JsonTable } from './JsonTable'
+import { Table } from '../Table'
+import { tableData } from '../../types/tableTypes'
+
+interface TestEntry extends tableData {
+  name: string
+}
+
+// Access private flush fields for race coverage without widening production API.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function internals(table: JsonTable<TestEntry>): any {
+  return table
+}
+
+describe('JsonTable.crupdate and ioBuffer', () => {
+  let tempDir: string
+
+  beforeEach(() => {
+    Table.all.clear()
+    tempDir = mkdtempSync(path.join(tmpdir(), 'tablet-json-'))
+  })
+
+  afterEach(() => {
+    Table.all.clear()
+    rmSync(tempDir, { recursive: true, force: true })
+  })
+
+  it('treats _version 0 as present and bumps to 1', async () => {
+    const table = new JsonTable<TestEntry>('VersionZero', tempDir)
+    await table.loadPromise
+    clearInterval(internals(table).ioBufferInterval)
+
+    const result = await table.crupdate({
+      _id: 'a',
+      _version: 0,
+      name: 'zero',
+    })
+
+    expect(result).toEqual(
+      expect.objectContaining({ _id: 'a', _version: 1, name: 'zero' })
+    )
+  })
+
+  it('keeps bufferWrite true when a write lands during flush', async () => {
+    const table = new JsonTable<TestEntry>('FlushRace', tempDir)
+    await table.loadPromise
+    const t = internals(table)
+    clearInterval(t.ioBufferInterval)
+
+    await table.crupdate({
+      _id: 'a',
+      _version: undefined,
+      name: 'first',
+    })
+    expect(t.bufferWrite).toBe(true)
+    const generationBeforeFlush = t.writeGeneration
+
+    let resolveSave!: () => void
+    const saveGate = new Promise<void>((resolve) => {
+      resolveSave = resolve
+    })
+    const originalSave = t.saveTable.bind(table)
+    jest.spyOn(t, 'saveTable').mockImplementation(async () => {
+      await saveGate
+      return originalSave()
+    })
+
+    t.ioBuffer()
+    // Mid-flush write bumps generation while save is still in flight.
+    await table.crupdate({
+      _id: 'a',
+      _version: 1,
+      name: 'second',
+    })
+    expect(t.writeGeneration).toBeGreaterThan(generationBeforeFlush)
+
+    resolveSave()
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(t.bufferWrite).toBe(true)
+  })
+})

--- a/src/json/JsonTable.ts
+++ b/src/json/JsonTable.ts
@@ -30,6 +30,7 @@ class JsonTable<T extends tableData> extends Table<T> {
   public readonly filePath: PathLike
   private cache: Map<string, T> = new Map<string, T>()
   private bufferWrite = false
+  private writeGeneration = 0
   private ioBufferInterval = setInterval(() => this.ioBuffer(), 1000)
   /**
    *
@@ -42,6 +43,9 @@ class JsonTable<T extends tableData> extends Table<T> {
     this.filePath = path.join(this.dirPath.toString(), name + fileExt)
     this.summary['FILE'] = { value: this.filePath.toString() }
     this.loadPromise = this.loadTable()
+    if (typeof this.ioBufferInterval.unref === 'function') {
+      this.ioBufferInterval.unref()
+    }
   }
   /**
    * @returns how many entries are in this table
@@ -131,10 +135,11 @@ class JsonTable<T extends tableData> extends Table<T> {
 
     const updatedEntry: T = {
       ...entry,
-      _version: entry._version ? entry._version + 1 : 1,
+      _version: entry._version != null ? entry._version + 1 : 1,
     }
 
     this.cache.set(entry._id, updatedEntry)
+    this.writeGeneration++
     this.bufferWrite = true
     this.summary.UPDATES.value++
     return updatedEntry
@@ -166,16 +171,23 @@ class JsonTable<T extends tableData> extends Table<T> {
    */
   public async delete(entry: T) {
     const res = this.cache.delete(entry._id)
+    this.writeGeneration++
     this.bufferWrite = true
     return res
   }
 
   private ioBuffer() {
-    if (this.bufferWrite) {
-      this.saveTable()
-        .then(() => (this.bufferWrite = false))
-        .catch((err) => console.log(err))
-    }
+    if (!this.bufferWrite) return
+    const generationAtStart = this.writeGeneration
+    this.saveTable()
+      .then(() => {
+        // Only clear when no writes landed during the flush; otherwise keep
+        // bufferWrite so the next interval persists the newer cache state.
+        if (this.writeGeneration === generationAtStart) {
+          this.bufferWrite = false
+        }
+      })
+      .catch((err) => console.log(err))
   }
 
   private async saveTable() {
@@ -211,17 +223,16 @@ class JsonTable<T extends tableData> extends Table<T> {
 
       return true
     } catch (err) {
+      const errno = err as NodeJS.ErrnoException
+      if (errno?.code === 'ENOENT') {
+        if (this.retries > 3)
+          throw `TABLET_ERROR: JsonTable.load failed after ${this.retries} attempts`
+        this.retries++
+        await this.saveTable()
+        return this.loadTable()
+      }
       if (err instanceof Error) {
-        if (
-          err.message ==
-          `ENOENT: no such file or directory, open '${this.filePath}'`
-        ) {
-          if (this.retries > 3)
-            throw `TABLET_ERROR: JsonTable.load failed after ${this.retries} attempts`
-          this.retries++
-          await this.saveTable()
-          return this.loadTable()
-        } else if (err.name.substring(0, 11) == 'SyntaxError') {
+        if (err.name.substring(0, 11) == 'SyntaxError') {
           throw `TABLET_ERROR: JSONTABLE FILE ${this.filePath} IS INCORRECTLY FORMATTED`
         } else {
           console.log(err.message.substring(0, 10))

--- a/src/mongodb/MongoTable.crupdate.test.ts
+++ b/src/mongodb/MongoTable.crupdate.test.ts
@@ -96,4 +96,26 @@ describe('MongoTable.crupdate', () => {
       { upsert: false, returnDocument: 'after' }
     )
   })
+
+  it('bumps _version 0 to 1 instead of treating 0 as missing', async () => {
+    const table = createTable('VersionZero')
+    await table.loadPromise
+
+    const entry: TestEntry = {
+      _id: 'player-4',
+      name: 'Dee',
+      _version: 0,
+    }
+    const saved: TestEntry = { ...entry, _version: 1 }
+    mockFindOneAndUpdate.mockResolvedValue(saved)
+
+    const result = await table.crupdate(entry)
+
+    expect(result).toEqual(saved)
+    expect(mockFindOneAndUpdate).toHaveBeenCalledWith(
+      { _id: 'player-4', _version: 0 },
+      { $set: { name: 'Dee', _version: 1 } },
+      { upsert: false, returnDocument: 'after' }
+    )
+  })
 })

--- a/src/mongodb/MongoTable.ts
+++ b/src/mongodb/MongoTable.ts
@@ -53,7 +53,7 @@ class MongoTable<T extends tableData> extends Table<T> {
           _version: entry._version,
         } as Filter<T>)
       : ({ _id } as Filter<T>)
-    const newVersion = entry._version ? entry._version + 1 : 1
+    const newVersion = entry._version != null ? entry._version + 1 : 1
     const result = await this.collection.findOneAndUpdate(
       filter,
       {

--- a/src/sheets/SheetTable.ts
+++ b/src/sheets/SheetTable.ts
@@ -41,7 +41,7 @@ export class SheetTable<T extends baseTableData> extends Table<T> {
     this.loadPromise = this.load()
     this.loadPromise
       .then(() => {
-        this.summary['SPREADSHEET'] = this.spreadsheet.title
+        this.summary['SPREADSHEET'] = { value: this.spreadsheet.title }
       })
       .catch((err) => {
         console.log(`error loading ${this.name}`)
@@ -101,7 +101,7 @@ export class SheetTable<T extends baseTableData> extends Table<T> {
     if (changes) {
       try {
         await limiter.removeTokens(1)
-        this.rows[index].lastUpdate = nowString()
+        this.rows[index].set('lastUpdate', nowString())
         await this.rows[index].save({ raw: true })
         return true
       } catch (err) {
@@ -183,9 +183,9 @@ export class SheetTable<T extends baseTableData> extends Table<T> {
       if (
         header != 'lastUpdate' &&
         flatValue &&
-        this.rows[index][header] != flatValue
+        this.rows[index].get(header) != flatValue
       ) {
-        this.rows[index][header] = flatValue
+        this.rows[index].set(header, flatValue)
         changes = true
       }
     })
@@ -272,12 +272,12 @@ export class SheetTable<T extends baseTableData> extends Table<T> {
     this.headers.forEach((header) => {
       if (failure) return
       try {
-        parsedObject[header] = parseVal(row[header])
+        parsedObject[header] = parseVal(row.get(header))
       } catch (err) {
         console.log(
           `unable to parse ${header} of ${this.name} at row ${row.rowNumber}:`
         )
-        console.log(row[header])
+        console.log(row.get(header))
         failure = true
         return null
       }
@@ -287,7 +287,7 @@ export class SheetTable<T extends baseTableData> extends Table<T> {
 
   private findRowIndexById = (_id: string): number => {
     const index = this.rows.findIndex(
-      (row) => parseVal(row._id)?.toString() === _id.toString()
+      (row) => parseVal(row.get('_id'))?.toString() === _id.toString()
     )
     return index
   }

--- a/src/sheets/sheetsUtil.ts
+++ b/src/sheets/sheetsUtil.ts
@@ -1,3 +1,4 @@
+import { JWT } from 'google-auth-library'
 import { RateLimiter } from 'limiter'
 import { GoogleSpreadsheet as Spreadsheet } from 'google-spreadsheet'
 
@@ -10,6 +11,8 @@ interface spreadsheetInfo {
   gKey: gKey
   spreadsheetId: string
 }
+
+const SHEETS_SCOPES = ['https://www.googleapis.com/auth/spreadsheets']
 
 const limiter = new RateLimiter({ tokensPerInterval: 1, interval: 1000 })
 
@@ -29,12 +32,17 @@ const loadSpreadsheet = async (
     return loadPromise
   } catch (err) {
     if (err) console.log(err)
+    throw err
   }
 }
 
 const load = async (spreadsheetInfo: spreadsheetInfo): Promise<Spreadsheet> => {
-  const spreadsheet = new Spreadsheet(spreadsheetInfo.spreadsheetId)
-  await spreadsheet.useServiceAccountAuth(spreadsheetInfo.gKey)
+  const auth = new JWT({
+    email: spreadsheetInfo.gKey.client_email,
+    key: spreadsheetInfo.gKey.private_key,
+    scopes: SHEETS_SCOPES,
+  })
+  const spreadsheet = new Spreadsheet(spreadsheetInfo.spreadsheetId, auth)
   await spreadsheet.loadInfo()
   console.log(` Tablet: Connected to spreadsheet '${spreadsheet.title}'`)
   return spreadsheet


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Upgrades `google-spreadsheet` from `^3.3.0` to `^5.3.0` and adds peer dependency `google-auth-library`.
- Removes the vulnerable production transitive `axios` dependency (v5 uses `ky` instead).
- Migrates Sheets auth from removed `useServiceAccountAuth` to `JWT` credentials passed into the `GoogleSpreadsheet` constructor.
- Updates row field access to the v5 `get`/`set` API, and stores spreadsheet title as a `summaryEntry` (`{ value }`).

## Verification
- `npm audit --omit=dev`: **0 vulnerabilities**
- `npm test`: 4 suites / 11 tests passed
- `npx tsc --noEmit`: clean

## Notes
- This is intentionally separate from the non-breaking `npm audit fix` PR; remaining audit findings after this are primarily in the Jest/ESLint (dev) dependency tree.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-79b9cff7-6ad1-4670-9215-35559922577b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-79b9cff7-6ad1-4670-9215-35559922577b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

